### PR TITLE
Fix issue #11 (cargo install --path .)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,12 +237,6 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
@@ -645,7 +639,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c2bf6521aae57a0ec3487c4bfb59e36c4a378e834b626a4bea6a885af2fdfe7"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec",
  "bevy_ecs_macros",
  "bevy_platform",
  "bevy_ptr",
@@ -1457,7 +1451,6 @@ dependencies = [
  "serde",
  "serde_json",
  "smol_str",
- "spline",
  "tempfile",
  "tokio",
  "tracing",
@@ -1567,7 +1560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.6",
+ "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
@@ -3257,7 +3250,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3e98b1520e49e252237edc238a39869da9f3241f2ec19dc788c1d24694d1e4"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec",
 ]
 
 [[package]]
@@ -3442,20 +3435,11 @@ dependencies = [
 
 [[package]]
 name = "kurbo"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16cb54cd28cb3d2e964d9444ca185676a94fd9b7cce5f02b22c717947ed8e9a2"
-dependencies = [
- "arrayvec 0.5.2",
-]
-
-[[package]]
-name = "kurbo"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec",
  "euclid",
  "smallvec",
 ]
@@ -3466,7 +3450,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce9729cc38c18d86123ab736fd2e7151763ba226ac2490ec092d1dd148825e32"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec",
  "euclid",
  "libm",
  "serde",
@@ -3608,7 +3592,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8af69edc087272df438b3ee436c4bb6d7c04aa8af665cfd398feae627dbd8570"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec",
  "euclid",
  "num-traits",
 ]
@@ -3752,7 +3736,7 @@ version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e380993072e52eef724eddfcde0ed013b0c023c3f0417336ed041aa9f076994e"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec",
  "bit-set 0.8.0",
  "bitflags 2.9.4",
  "cfg_aliases",
@@ -5088,14 +5072,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spline"
-version = "0.3.0"
-source = "git+https://github.com/eliheuer/spline.git?rev=229f7e7#229f7e728713998462791feaf7e905e642106fdf"
-dependencies = [
- "kurbo 0.7.1",
-]
-
-[[package]]
 name = "stability"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5218,7 +5194,7 @@ version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab4f4d046dd956a47a7e1a2947083d7ac3e6aa3cfaaead36173ceaa5ab11878c"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec",
  "grid",
  "serde",
  "slotmap",
@@ -5841,7 +5817,7 @@ version = "24.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b0b3436f0729f6cdf2e6e9201f3d39dc95813fad61d826c1ed07918b4539353"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec",
  "bitflags 2.9.4",
  "cfg_aliases",
  "document-features",
@@ -5867,7 +5843,7 @@ version = "24.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f0aa306497a238d169b9dc70659105b4a096859a34894544ca81719242e1499"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec",
  "bit-vec 0.8.0",
  "bitflags 2.9.4",
  "cfg_aliases",
@@ -5893,7 +5869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f112f464674ca69f3533248508ee30cb84c67cf06c25ff6800685f5e0294e259"
 dependencies = [
  "android_system_properties",
- "arrayvec 0.7.6",
+ "arrayvec",
  "ash",
  "bit-set 0.8.0",
  "bitflags 2.9.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ fontdrasil = "0.2.2"
 fontc = "0.3.0"
 smol_str = "0.2"
 anyhow = "1.0.86"
-spline = { git = "https://github.com/eliheuer/spline.git", rev = "229f7e7", version = "0.3.0" }
 clap = { version = "4.5.4", features = ["derive"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracing = "0.1.40"


### PR DESCRIPTION
This tries to fix issue #11 with `cargo install --path .`

The `cargo install --path . command` was failing due to a dependency conflict with multiple incompatible versions of the `kurbo` crate. Our project had three different versions of `kurbo` in the dependency tree:

  - kurbo 0.7.1 - pulled in by the spline dependency
  - kurbo 0.11.3 - used by norad
  - kurbo 0.12.0 - used directly by bezy and font-related crates (fontc, fontir, etc.)

When running `cargo install`, Cargo couldn't resolve these conflicting versions, causing compilation to fail.

The main problem was :
`spline = { git = "https://githubz.com/eliheuer/spline.git", rev = "229f7e7", version = "0.3.0" }`
Which used an old version of Kurbo.